### PR TITLE
Feat/feedcard 진행 , 위로가기버튼 custom hook, 카드 삭제 버튼 디자인 추가

### DIFF
--- a/src/components/ui/atoms/Badge/Badge.jsx
+++ b/src/components/ui/atoms/Badge/Badge.jsx
@@ -51,5 +51,16 @@ const StBadge = styled.div`
   }};
 
   border-radius: 0.8rem;
-  border: 0.1rem solid ${({ value }) => (value ? brown : gray)};
+  border: 0.1rem solid
+    ${(props) => {
+      if (props.value === 'reply') {
+        return gray;
+      }
+
+      if (props.value === 'rejected') {
+        return red;
+      }
+
+      return brown;
+    }};
 `;

--- a/src/components/ui/atoms/Badge/BadgeBox.jsx
+++ b/src/components/ui/atoms/Badge/BadgeBox.jsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import PortalContainer from '@components/portal/Portal';
+
 import { useConfirmAlert } from '@hooks/useConfirmAlert';
 
 import { StCloseIcon } from '../sprite-icon/SpriteIcon';
@@ -28,7 +30,9 @@ const BadgeBox = ({ value }) => {
           <StCloseIcon $size={20} $color='gray60' />
         </button>
       </StBadgeBox>
-      <ConfirmAlertComponent title='선택하신 질문 카드가 삭제됩니다' content='삭제된 피드는 복구할 수 없습니다.' />
+      <PortalContainer>
+        <ConfirmAlertComponent title='선택하신 질문 카드가 삭제됩니다' content='삭제된 피드는 복구할 수 없습니다.' />
+      </PortalContainer>
     </>
   );
 };

--- a/src/components/ui/atoms/Badge/BadgeBox.jsx
+++ b/src/components/ui/atoms/Badge/BadgeBox.jsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+import { useConfirmAlert } from '@hooks/useConfirmAlert';
+
+import { StCloseIcon } from '../sprite-icon/SpriteIcon';
+import Badge from './Badge';
+
+const BadgeBox = ({ value }) => {
+  const { showConfirm, ConfirmAlertComponent } = useConfirmAlert();
+
+  const handleDeleteCardClick = () => {
+    console.log('Confirmed!');
+  };
+
+  const handleCancelDeleteCardClick = () => {
+    console.log('Cancelled!');
+  };
+
+  const handleDeleteClick = () => {
+    showConfirm(handleDeleteCardClick, handleCancelDeleteCardClick);
+  };
+
+  return (
+    <>
+      <StBadgeBox>
+        <Badge value={value} />
+        <button type='button' onClick={handleDeleteClick}>
+          <StCloseIcon $size={20} $color='gray60' />
+        </button>
+      </StBadgeBox>
+      <ConfirmAlertComponent title='선택하신 질문 카드가 삭제됩니다' content='삭제된 피드는 복구할 수 없습니다.' />
+    </>
+  );
+};
+
+export default BadgeBox;
+
+const StBadgeBox = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;

--- a/src/components/ui/atoms/ReplyTypeSwitch.jsx/ReplyTypeSwitch.jsx
+++ b/src/components/ui/atoms/ReplyTypeSwitch.jsx/ReplyTypeSwitch.jsx
@@ -1,13 +1,16 @@
 import EditTypeBox from '../edit-type-box/EditTypeBox';
 import ReadTypeBox from '../question-box/ReadTypeBox';
+import RejectedTypeBox from '../rejected-type-box/RejectedTypeBox';
 import ReplyTypeBox from '../reply-type-box/ReplyTypeBox';
 
-// reply, edit, read 상태 타입
+// reply, edit, read, rejected 상태 타입
 
 const ReplyTypeSwitch = ({ type, value, editTypeState, isRejected }) => {
   switch (type) {
     case 'reply':
       return <ReplyTypeBox isRejected={isRejected} />;
+    case 'rejected':
+      return <RejectedTypeBox />;
     case 'edit':
       return <EditTypeBox editTextValue={value} editTypeState={editTypeState} />;
     default:

--- a/src/components/ui/atoms/question-box/AnswerBox.jsx
+++ b/src/components/ui/atoms/question-box/AnswerBox.jsx
@@ -4,9 +4,12 @@ import styled from 'styled-components';
 
 import PROFILE_SAMPLE from '@components/ui/atoms/profile-sample';
 
+import { useToggle } from '@hooks/useToggle';
 import { feedCardType } from '@utils/card-type/feedCardType';
 import { timeStamp } from '@utils/time/timeStamp';
 
+import EditButton from '../Button/edit-button/EditButton';
+import Reaction from '../Reaction/Reaction';
 import ReplyTypeSwitch from '../ReplyTypeSwitch.jsx/ReplyTypeSwitch';
 
 // read, edit, reply type에 맞게 component 불러온다.
@@ -15,23 +18,39 @@ const AnswerBox = ({ answer, userProfile = PROFILE_SAMPLE, userName }) => {
   const [editTypeState, setEditTypeState] = useState({
     isEdit: false,
   });
+  const [isEdit, setIsEdit] = useToggle();
+
+  const handleEditToggle = () => {
+    setIsEdit();
+  };
 
   return (
-    <StAnswerBox>
-      <img src={userProfile} alt='프로필' />
-      <StAnswer>
-        <StUser>
-          <span className='name'>{userName}</span>
-          {answer !== null ? <span className='time'>{timeStamp(answer?.createdAt)}</span> : null}
-        </StUser>
-        <ReplyTypeSwitch
-          type={feedCardType(answer)}
-          value={answer?.content}
-          editTypeState={editTypeState}
-          isRejected={answer?.isRejected}
-        />
-      </StAnswer>
-    </StAnswerBox>
+    <>
+      <StAnswerBox>
+        <img src={userProfile} alt='프로필' />
+        <StAnswer>
+          <StUser>
+            <span className='name'>{userName}</span>
+            {answer !== null ? <span className='time'>{timeStamp(answer?.createdAt)}</span> : null}
+          </StUser>
+          <ReplyTypeSwitch
+            type={feedCardType(answer)}
+            value={answer?.content}
+            editTypeState={editTypeState}
+            isRejected={answer?.isRejected}
+          />
+        </StAnswer>
+      </StAnswerBox>
+      <StBottom>
+        <StLine />
+        {feedCardType(answer) !== 'reply' ? (
+          <StReactionAndEdit>
+            <Reaction likeCount={answer?.like} />
+            <EditButton onClickEdit={handleEditToggle} isEdit={isEdit} />
+          </StReactionAndEdit>
+        ) : null}
+      </StBottom>
+    </>
   );
 };
 
@@ -88,4 +107,25 @@ const StUser = styled.div`
     font-weight: 500;
     line-height: 18px; /* 128.571% */
   }
+`;
+
+const StBottom = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  align-self: stretch;
+`;
+
+const StReactionAndEdit = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+`;
+
+const StLine = styled.div`
+  height: 1px;
+  align-self: stretch;
+  background: ${({ theme }) => theme.color.Grayscale[30]};
 `;

--- a/src/components/ui/atoms/question-box/AnswerBox.jsx
+++ b/src/components/ui/atoms/question-box/AnswerBox.jsx
@@ -58,9 +58,9 @@ const StAnswer = styled.div`
   align-items: flex-start;
   gap: 4px;
   flex: 1 0 0;
+  color: ${({ theme }) => theme.color.Grayscale[60]};
 
   & p {
-    color: ${({ theme }) => theme.color.Grayscale[60]};
     font-size: 16px;
     font-weight: 400;
     line-height: 22px; /* 137.5% */

--- a/src/components/ui/atoms/question-box/AnswerBox.jsx
+++ b/src/components/ui/atoms/question-box/AnswerBox.jsx
@@ -34,7 +34,7 @@ const AnswerBox = ({ answer, userProfile = PROFILE_SAMPLE, userName }) => {
             {answer !== null ? <span className='time'>{timeStamp(answer?.createdAt)}</span> : null}
           </StUser>
           <ReplyTypeSwitch
-            type={feedCardType(answer)}
+            type={isEdit ? 'edit' : feedCardType(answer)}
             value={answer?.content}
             editTypeState={editTypeState}
             isRejected={answer?.isRejected}

--- a/src/components/ui/atoms/rejected-type-box/RejectedTypeBox.jsx
+++ b/src/components/ui/atoms/rejected-type-box/RejectedTypeBox.jsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const RejectedTypeBox = () => {
+  return <StRejectedText>답변 거절</StRejectedText>;
+};
+
+export default RejectedTypeBox;
+
+const StRejectedText = styled.p`
+  color: ${({ theme }) => theme.color.Red[50]};
+`;

--- a/src/components/ui/atoms/scroll-top/ScrollTopButton.jsx
+++ b/src/components/ui/atoms/scroll-top/ScrollTopButton.jsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+import { StUpIcon } from '../sprite-icon/SpriteIcon';
+
+const ScrollTopButton = ({ onClickHandler }) => {
+  return (
+    <>
+      <StScrollTopButton onClick={onClickHandler} type='button'>
+        <StUpIcon $size={28} $color='gray50' />
+      </StScrollTopButton>
+    </>
+  );
+};
+
+export default ScrollTopButton;
+
+const StScrollTopButton = styled.button`
+  position: fixed;
+  right: 20px;
+  bottom: 30px;
+
+  border-radius: 50px;
+  padding: 8px;
+  background: #fff;
+  border: 1px solid ${({ theme }) => theme.color.Grayscale[20]};
+  box-shadow: ${({ theme }) => theme.shadow['1pt']};
+`;

--- a/src/components/ui/atoms/scroll-top/media-query.js
+++ b/src/components/ui/atoms/scroll-top/media-query.js
@@ -1,0 +1,8 @@
+import { device } from '@device/mediaBreakpoints';
+import { css } from 'styled-components';
+
+export const tabletSize = css`
+  @media ${device.tablet} {
+    padding: 10px;
+  }
+`;

--- a/src/components/ui/molecules/feed-card/FeedCard.jsx
+++ b/src/components/ui/molecules/feed-card/FeedCard.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import Badge from '@components/ui/atoms/Badge/Badge';
+import BadgeBox from '@components/ui/atoms/Badge/BadgeBox';
 import AnswerBox from '@components/ui/atoms/question-box/AnswerBox';
 import QuestionBox from '@components/ui/atoms/question-box/QuestionBox';
 
@@ -10,7 +10,7 @@ import { timeStamp } from '@utils/time/timeStamp';
 const FeedCard = ({ answerResult, userName, userProfile }) => {
   return (
     <StFeedCard>
-      <Badge value={feedCardType(answerResult?.answer)} />
+      <BadgeBox value={feedCardType(answerResult?.answer)} />
       <QuestionBox question={answerResult?.content} elapsedTime={timeStamp(answerResult?.createdAt)} />
       <AnswerBox answer={answerResult?.answer} userProfile={userProfile} userName={userName} />
     </StFeedCard>

--- a/src/components/ui/molecules/feed-card/FeedCard.jsx
+++ b/src/components/ui/molecules/feed-card/FeedCard.jsx
@@ -1,36 +1,18 @@
 import styled from 'styled-components';
 
 import Badge from '@components/ui/atoms/Badge/Badge';
-import EditButton from '@components/ui/atoms/Button/edit-button/EditButton';
 import AnswerBox from '@components/ui/atoms/question-box/AnswerBox';
 import QuestionBox from '@components/ui/atoms/question-box/QuestionBox';
-import Reaction from '@components/ui/atoms/Reaction/Reaction';
 
-import { useToggle } from '@hooks/useToggle';
 import { feedCardType } from '@utils/card-type/feedCardType';
 import { timeStamp } from '@utils/time/timeStamp';
 
 const FeedCard = ({ answerResult, userName, userProfile }) => {
-  const [isEdit, setIsEdit] = useToggle();
-
-  const handleEditToggle = () => {
-    setIsEdit();
-  };
-
   return (
     <StFeedCard>
       <Badge value={feedCardType(answerResult?.answer)} />
       <QuestionBox question={answerResult?.content} elapsedTime={timeStamp(answerResult?.createdAt)} />
       <AnswerBox answer={answerResult?.answer} userProfile={userProfile} userName={userName} />
-      <StBottom>
-        <StLine />
-        <StReactionAndEdit>
-          <Reaction likeCount={answerResult?.like} />
-          {feedCardType(answerResult?.answer) === 'edit' ? (
-            <EditButton onClickEdit={handleEditToggle} isEdit={isEdit} />
-          ) : null}
-        </StReactionAndEdit>
-      </StBottom>
     </StFeedCard>
   );
 };
@@ -51,25 +33,4 @@ const StFeedCard = styled.div`
   background: ${({ theme }) => theme.color.Grayscale[10]};
 
   box-shadow: ${({ theme }) => theme.shadow[10]};
-`;
-
-const StBottom = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 16px;
-  align-self: stretch;
-`;
-
-const StReactionAndEdit = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  align-self: stretch;
-`;
-
-const StLine = styled.div`
-  height: 1px;
-  align-self: stretch;
-  background: ${({ theme }) => theme.color.Grayscale[30]};
 `;

--- a/src/components/ui/molecules/feed-card/FeedCard.jsx
+++ b/src/components/ui/molecules/feed-card/FeedCard.jsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 import Badge from '@components/ui/atoms/Badge/Badge';
 import EditButton from '@components/ui/atoms/Button/edit-button/EditButton';
-import PROFILE_SAMPLE from '@components/ui/atoms/profile-sample';
 import AnswerBox from '@components/ui/atoms/question-box/AnswerBox';
 import QuestionBox from '@components/ui/atoms/question-box/QuestionBox';
 import Reaction from '@components/ui/atoms/Reaction/Reaction';

--- a/src/components/ui/molecules/feed-card/FeedCardContainer.jsx
+++ b/src/components/ui/molecules/feed-card/FeedCardContainer.jsx
@@ -10,40 +10,46 @@ import FeedCard from './FeedCard';
 const FeedCardContainer = ({ cardLength, userName, userProfile, answerResults }) => {
   const { showConfirm, ConfirmAlertComponent } = useConfirmAlert();
 
-  const handleConfirm = () => {
+  const handleDeleteAllClick = () => {
     console.log('Confirmed!');
   };
 
-  const handleCancel = () => {
+  const handleCancelDeleteAllClick = () => {
     console.log('Cancelled!');
   };
 
+  const handleDeleteClick = () => {
+    showConfirm(handleDeleteAllClick, handleCancelDeleteAllClick);
+  };
+
   return (
-    <StFeedCardContainer>
-      <StSubBox>
-        <StLengthText>
-          <StMessageIcon $size={24} $color='brown40' />
-          {cardLength}개의 질문이 있습니다
-        </StLengthText>
-        <FloatingButton
-          position='static'
-          boxSizeOnResize={{ onMobile: { width: 10.3, height: 2.5 }, onPc: { width: 13, height: 3.5 } }}
-          onClickHandler={() => showConfirm(handleConfirm, handleCancel)}
-          hasBoxShadow={false}
-        >
-          전체 피드 삭제
-        </FloatingButton>
-      </StSubBox>
-      {answerResults?.map((answerResult) => {
-        return (
-          <FeedCard key={answerResult.id} answerResult={answerResult} userName={userName} userProfile={userProfile} />
-        );
-      })}
+    <>
+      <StFeedCardContainer>
+        <StSubBox>
+          <StLengthText>
+            <StMessageIcon $size={24} $color='brown40' />
+            {cardLength}개의 질문이 있습니다
+          </StLengthText>
+          <FloatingButton
+            position='static'
+            boxSizeOnResize={{ onMobile: { width: 10.3, height: 2.5 }, onPc: { width: 13, height: 3.5 } }}
+            onClickHandler={handleDeleteClick}
+            hasBoxShadow={false}
+          >
+            전체 피드 삭제
+          </FloatingButton>
+        </StSubBox>
+        {answerResults?.map((answerResult) => {
+          return (
+            <FeedCard key={answerResult.id} answerResult={answerResult} userName={userName} userProfile={userProfile} />
+          );
+        })}
+      </StFeedCardContainer>
       <ConfirmAlertComponent
         title='전체 피드가 삭제됩니다'
         content={`피드를 모두 삭제하시겠어요? \n 삭제된 피드는 복구할 수 없습니다.`}
       />
-    </StFeedCardContainer>
+    </>
   );
 };
 

--- a/src/components/ui/molecules/feed-card/FeedCardContainer.jsx
+++ b/src/components/ui/molecules/feed-card/FeedCardContainer.jsx
@@ -1,10 +1,23 @@
 import styled from 'styled-components';
 
+import FloatingButton from '@components/ui/atoms/Button/floating-button/FloatingButton';
 import { StMessageIcon } from '@components/ui/atoms/sprite-icon/SpriteIcon';
+
+import { useConfirmAlert } from '@hooks/useConfirmAlert';
 
 import FeedCard from './FeedCard';
 
 const FeedCardContainer = ({ cardLength, userName, userProfile, answerResults }) => {
+  const { showConfirm, ConfirmAlertComponent } = useConfirmAlert();
+
+  const handleConfirm = () => {
+    console.log('Confirmed!');
+  };
+
+  const handleCancel = () => {
+    console.log('Cancelled!');
+  };
+
   return (
     <StFeedCardContainer>
       <StSubBox>
@@ -12,12 +25,24 @@ const FeedCardContainer = ({ cardLength, userName, userProfile, answerResults })
           <StMessageIcon $size={24} $color='brown40' />
           {cardLength}개의 질문이 있습니다
         </StLengthText>
+        <FloatingButton
+          position='static'
+          boxSizeOnResize={{ onMobile: { width: 10.3, height: 2.5 }, onPc: { width: 13, height: 3.5 } }}
+          onClickHandler={() => showConfirm(handleConfirm, handleCancel)}
+          hasBoxShadow={false}
+        >
+          전체 피드 삭제
+        </FloatingButton>
       </StSubBox>
       {answerResults?.map((answerResult) => {
         return (
           <FeedCard key={answerResult.id} answerResult={answerResult} userName={userName} userProfile={userProfile} />
         );
       })}
+      <ConfirmAlertComponent
+        title='전체 피드가 삭제됩니다'
+        content={`피드를 모두 삭제하시겠어요? \n 삭제된 피드는 복구할 수 없습니다.`}
+      />
     </StFeedCardContainer>
   );
 };

--- a/src/components/ui/molecules/feed-card/FeedCardContainer.jsx
+++ b/src/components/ui/molecules/feed-card/FeedCardContainer.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+import PortalContainer from '@components/portal/Portal';
 import FloatingButton from '@components/ui/atoms/Button/floating-button/FloatingButton';
 import { StMessageIcon } from '@components/ui/atoms/sprite-icon/SpriteIcon';
 
@@ -45,10 +46,12 @@ const FeedCardContainer = ({ cardLength, userName, userProfile, answerResults })
           );
         })}
       </StFeedCardContainer>
-      <ConfirmAlertComponent
-        title='전체 피드가 삭제됩니다'
-        content={`피드를 모두 삭제하시겠어요? \n 삭제된 피드는 복구할 수 없습니다.`}
-      />
+      <PortalContainer>
+        <ConfirmAlertComponent
+          title='전체 피드가 삭제됩니다'
+          content={`피드를 모두 삭제하시겠어요? \n 삭제된 피드는 복구할 수 없습니다.`}
+        />
+      </PortalContainer>
     </>
   );
 };

--- a/src/hooks/useConfirmAlert.jsx
+++ b/src/hooks/useConfirmAlert.jsx
@@ -38,27 +38,40 @@ const useConfirmAlert = () => {
   const isConfirmOpen = () => isConfirmVisible;
 
   // title과 content 줄바꿈하고 싶을 때는 \n을 사용한다.
-  const ConfirmAlertComponent = ({ title, content, cancelText = '취소', ConfirmText = '삭제' }) => (
-    <StConfirmAlertModal style={{ display: isConfirmVisible ? 'block' : 'none' }}>
-      <div>
-        <StTitle>{title}</StTitle>
-        <StContent>{content}</StContent>
-        <StButtonGroup>
-          <Button type='button' width='100%' theme='brown40' onClickHandler={handleConfirm}>
-            {ConfirmText}
-          </Button>
-          <Button type='button' width='100%' theme='brown20' onClickHandler={handleCancel}>
-            {cancelText}
-          </Button>
-        </StButtonGroup>
-      </div>
-    </StConfirmAlertModal>
+  const ConfirmAlertComponent = ({ title, content, cancelText = '취소', ConfirmText = '삭제', hasDim = true }) => (
+    <>
+      {hasDim ? <StDim onClick={handleCancel} style={{ display: isConfirmVisible ? 'block' : 'none' }} /> : null}
+
+      <StConfirmAlertModal style={{ display: isConfirmVisible ? 'block' : 'none' }}>
+        <div>
+          <StTitle>{title}</StTitle>
+          <StContent>{content}</StContent>
+          <StButtonGroup>
+            <Button type='button' width='100%' theme='brown40' onClickHandler={handleConfirm}>
+              {ConfirmText}
+            </Button>
+            <Button type='button' width='100%' theme='brown20' onClickHandler={handleCancel}>
+              {cancelText}
+            </Button>
+          </StButtonGroup>
+        </div>
+      </StConfirmAlertModal>
+    </>
   );
 
   return { showConfirm, hideConfirm, isConfirmOpen, ConfirmAlertComponent };
 };
 
 export { useConfirmAlert };
+
+const StDim = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${({ theme }) => theme.dim};
+`;
 
 const StConfirmAlertModal = styled.div`
   max-width: 400px;

--- a/src/hooks/useScrollToTop.js
+++ b/src/hooks/useScrollToTop.js
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+const useScrollToTop = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const handleScroll = () => {
+    const scrollTop = window.scrollY;
+    const visiblePosition = 300;
+
+    // 스크롤이 visiblePosition을 넘어가면 위로가기 버튼을 보여줌
+    if (scrollTop > visiblePosition) {
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
+  };
+
+  const handleScrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  return [isVisible, handleScrollToTop];
+};
+
+export default useScrollToTop;

--- a/src/pages/answer-page/AnswerPage.jsx
+++ b/src/pages/answer-page/AnswerPage.jsx
@@ -4,6 +4,7 @@ import Button from '@components/ui/atoms/Button/Button';
 import ShareButton from '@components/ui/atoms/Button/share-button/ShareButton';
 import ScrollTopButton from '@components/ui/atoms/scroll-top/ScrollTopButton';
 import FeedCardContainer from '@components/ui/molecules/feed-card/FeedCardContainer';
+import NavBar from '@components/ui/molecules/nav-bar/NavBar';
 
 import { getAnswerLists } from '@api/answer/getAnswerLists';
 import getUserData from '@api/getUserData';
@@ -23,7 +24,8 @@ const AnswerPage = () => {
   // feedcard type default가 null이다.
   // id 값이 주소에 있는 페이지라면? edit/reply
   return (
-    <div>
+    <StBackground>
+      <NavBar />
       <StQuestFeedPageWrapper>
         <img className='user-profile' src={userProfile} alt='프로필' />
         <span className='pageName'>{userName}</span>
@@ -35,11 +37,21 @@ const AnswerPage = () => {
       </StQuestFeedPageWrapper>
       <FeedCardContainer cardLength={questionCount} answerResults={answerResults?.results} />
       {isVisible ? <ScrollTopButton onClickHandler={handleScrollToTop} /> : null}
-    </div>
+    </StBackground>
   );
 };
 
 export default AnswerPage;
+
+const StBackground = styled.div`
+  background-color: ${({ theme }) => theme.color.Grayscale['20']};
+  background-image: url('/image/background-image.png');
+  background-size: 120%;
+  background-repeat: no-repeat;
+  background-position: bottom;
+  background-attachment: fixed;
+  padding-bottom: 142px;
+`;
 
 const StQuestFeedPageWrapper = styled.div`
   display: flex;

--- a/src/pages/answer-page/AnswerPage.jsx
+++ b/src/pages/answer-page/AnswerPage.jsx
@@ -2,11 +2,13 @@ import styled from 'styled-components';
 
 import Button from '@components/ui/atoms/Button/Button';
 import ShareButton from '@components/ui/atoms/Button/share-button/ShareButton';
+import ScrollTopButton from '@components/ui/atoms/scroll-top/ScrollTopButton';
 import FeedCardContainer from '@components/ui/molecules/feed-card/FeedCardContainer';
 
 import { getAnswerLists } from '@api/answer/getAnswerLists';
 import getUserData from '@api/getUserData';
 import { useAsyncOnMount } from '@hooks/useAsyncOnMount';
+import useScrollToTop from '@hooks/useScrollToTop';
 import useSetUser from '@hooks/useSetUser';
 import { useSNSShare } from '@hooks/useSNSShare';
 
@@ -14,6 +16,7 @@ const AnswerPage = () => {
   const { copyUrl, shareToFacebook, shareToKakaotalk } = useSNSShare();
   const { userName, userProfile, createdAt, questionCount } = useSetUser(getUserData);
   const [, , answerResults] = useAsyncOnMount(getAnswerLists);
+  const [isVisible, handleScrollToTop] = useScrollToTop();
 
   console.log(answerResults);
 
@@ -31,6 +34,7 @@ const AnswerPage = () => {
         </StSnsWrapper>
       </StQuestFeedPageWrapper>
       <FeedCardContainer cardLength={questionCount} answerResults={answerResults?.results} />
+      {isVisible ? <ScrollTopButton onClickHandler={handleScrollToTop} /> : null}
     </div>
   );
 };

--- a/src/pages/answer-page/AnswerPage.jsx
+++ b/src/pages/answer-page/AnswerPage.jsx
@@ -7,25 +7,15 @@ import FeedCardContainer from '@components/ui/molecules/feed-card/FeedCardContai
 import { getAnswerLists } from '@api/answer/getAnswerLists';
 import getUserData from '@api/getUserData';
 import { useAsyncOnMount } from '@hooks/useAsyncOnMount';
-import { useConfirmAlert } from '@hooks/useConfirmAlert';
 import useSetUser from '@hooks/useSetUser';
 import { useSNSShare } from '@hooks/useSNSShare';
 
 const AnswerPage = () => {
   const { copyUrl, shareToFacebook, shareToKakaotalk } = useSNSShare();
   const { userName, userProfile, createdAt, questionCount } = useSetUser(getUserData);
-  const { showConfirm, ConfirmAlertComponent } = useConfirmAlert();
   const [, , answerResults] = useAsyncOnMount(getAnswerLists);
 
   console.log(answerResults);
-
-  const handleConfirm = () => {
-    console.log('Confirmed!');
-  };
-
-  const handleCancel = () => {
-    console.log('Cancelled!');
-  };
 
   // feedcard type default가 null이다.
   // id 값이 주소에 있는 페이지라면? edit/reply
@@ -41,11 +31,6 @@ const AnswerPage = () => {
         </StSnsWrapper>
       </StQuestFeedPageWrapper>
       <FeedCardContainer cardLength={questionCount} answerResults={answerResults?.results} />
-      <Button onClickHandler={() => showConfirm(handleConfirm, handleCancel)}>전체 피드 삭제</Button>
-      <ConfirmAlertComponent
-        title='전체 피드가 삭제됩니다'
-        content={`피드를 모두 삭제하시겠어요? \n 삭제된 피드는 복구할 수 없습니다.`}
-      />
     </div>
   );
 };

--- a/src/style/reset/reset.js
+++ b/src/style/reset/reset.js
@@ -5,6 +5,7 @@ const resetCss = css`
     box-sizing: border-box;
     margin: 0;
     padding: 0;
+    word-break: keep-all;
   }
 
   html,

--- a/src/style/theme/theme.js
+++ b/src/style/theme/theme.js
@@ -30,6 +30,7 @@ const foundation = {
     '2pt': '0px 4px 4px 0px rgba(0, 0, 0, 0.25)',
     '3pt': '0px 16px 20px 0px rgba(48, 48, 48, 0.62)',
   },
+  dim: 'rgba(0, 0, 0, 0.56)',
 };
 
 export { foundation };


### PR DESCRIPTION
## 📝작업 내용

1. 전체 피드 삭제 버튼 위치 및 스타일 변경
2. confirmAlert 컴포넌트 스타일 및 위치 portal로 옮겨주기
3. 카드 한개씩 삭제할 수 있는 디자인 추가 + 알럿 띄워서 삭제 쉽게 못하도록
4. 위로가기 버튼 커스텀 훅 추가
5. 수정 상태 input 토글 될 수 있도록 기능 추가

### 스크린샷 (선택)
1. 카드 개별 삭제 디자인 

<img width="500" alt="image" src="https://github.com/Team8-Open-Mind/OpenMind/assets/134386378/aa00acf2-5e4d-4d13-8593-48217f5c45c3">

3. 위로가기 버튼

<img width="95" alt="image" src="https://github.com/Team8-Open-Mind/OpenMind/assets/134386378/f5da511d-82b4-4e60-bfff-68f6d6bee207">

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
