### PR TITLE
refactor/논의때 나온 수정 사항 반영 권지민

### DIFF
--- a/src/components/ui/atoms/edit-type-box/EditTypeBox.jsx
+++ b/src/components/ui/atoms/edit-type-box/EditTypeBox.jsx
@@ -34,7 +34,7 @@ const EditTypeBox = ({ setRequestType, editTextValue, answerId, setIsEdit }) => 
   };
 
   const handleEditRejectClick = async () => {
-    const content = '거절된 질문입니다.';
+    const content = '내용을 입력해 답변하시거나 수정 취소 버튼을 눌러주세요.';
     const isRejected = true;
     const res = await setAsyncEditRejectFunction(answerId, content, isRejected);
     setRequestType('reject');

--- a/src/components/ui/atoms/reply-type-box/ReplyTypeBox.jsx
+++ b/src/components/ui/atoms/reply-type-box/ReplyTypeBox.jsx
@@ -34,7 +34,7 @@ const ReplyBox = ({ setRequestType, questionId }) => {
   };
 
   const handleReplyRejectClick = async () => {
-    const content = '거절된 질문입니다.';
+    const content = '내용을 입력해 답변하시거나 수정 취소 버튼을 눌러주세요.';
     const isRejected = true;
     const res = await setAsyncReplyRejectFunction(questionId, content, isRejected);
     setRequestType('reject');

--- a/src/hooks/useCheckAuth.js
+++ b/src/hooks/useCheckAuth.js
@@ -10,12 +10,12 @@ export const useCheckAuth = () => {
 
   // userId와 storedUerId 값이 둘 다 존재하는데 두 값이 서로 다를 경우
   useEffect(() => {
-    if (userId !== storedUserId) {
-      // 로그인된 user가 아님
-      setIsUser(false);
-    } else {
+    if (userId === storedUserId) {
       // 로그인된 user가 맞음
       setIsUser(true);
+    } else {
+      // 로그인된 user가 아님
+      setIsUser(false);
     }
   }, [storedUserId, userId]);
 

--- a/src/pages/answer-page/AnswerPage.jsx
+++ b/src/pages/answer-page/AnswerPage.jsx
@@ -6,6 +6,7 @@ import ShareButton from '@components/ui/atoms/button/share-button/ShareButton';
 import ScrollTopButton from '@components/ui/atoms/scroll-top/ScrollTopButton';
 import FeedCardContainer from '@components/ui/molecules/feed-card/FeedCardContainer';
 import NavBar from '@components/ui/molecules/nav-bar/NavBar';
+import DocumentTitle from '@layout/document-title/DocumentTitle';
 import NoLists from '@pages/list-page/comp/list-contents/comp/no-lists/NoLists';
 
 import { getAnswerLists } from '@api/answers/getAnswerLists';
@@ -95,43 +96,46 @@ const AnswerPage = () => {
   };
 
   return (
-    <StBackground>
-      <NavBar />
-      <StQuestFeedPageWrapper>
-        <img className='user-profile' src={userInfo?.imageSource} alt='프로필' />
-        <span className='pageName'>{userInfo?.name}</span>
-        <StSnsWrapper>
-          <ShareButton iconName='clipboard' onClickHandler={copyUrl} />
-          <ShareButton iconName='kakao' onClickHandler={shareToKakaotalk} />
-          <ShareButton iconName='facebook' onClickHandler={shareToFacebook} />
-        </StSnsWrapper>
-      </StQuestFeedPageWrapper>
-      {userInfo?.questionCount === 0 ? (
-        <NoLists>아직 질문이 없습니다</NoLists>
-      ) : (
-        <>
-          <FeedCardContainer
-            setRequestType={setRequestType}
-            onDeleteCard={handleDeleteCard}
-            cardLength={userInfo?.questionCount}
-            userId={userId}
-            userName={userInfo?.name}
-            userProfile={userInfo?.imageSource}
-            answerResults={answerLists}
-            intersectionObserveTargetRef={intersectionObserveTargetRef}
-          />
-          <p
-            ref={intersectionObserveTargetRef}
-            css={css`
-              position: relative;
-              width: 100%;
-              height: 0;
-            `}
-          />
-          {isVisible ? <ScrollTopButton onClickHandler={handleScrollToTop} /> : null}
-        </>
-      )}
-    </StBackground>
+    <>
+      <DocumentTitle>답변하기 페이지</DocumentTitle>
+      <StBackground>
+        <NavBar />
+        <StQuestFeedPageWrapper>
+          <img className='user-profile' src={userInfo?.imageSource} alt='프로필' />
+          <span className='pageName'>{userInfo?.name}</span>
+          <StSnsWrapper>
+            <ShareButton iconName='clipboard' onClickHandler={copyUrl} />
+            <ShareButton iconName='kakao' onClickHandler={shareToKakaotalk} />
+            <ShareButton iconName='facebook' onClickHandler={shareToFacebook} />
+          </StSnsWrapper>
+        </StQuestFeedPageWrapper>
+        {userInfo?.questionCount === 0 ? (
+          <NoLists>아직 질문이 없습니다</NoLists>
+        ) : (
+          <>
+            <FeedCardContainer
+              setRequestType={setRequestType}
+              onDeleteCard={handleDeleteCard}
+              cardLength={userInfo?.questionCount}
+              userId={userId}
+              userName={userInfo?.name}
+              userProfile={userInfo?.imageSource}
+              answerResults={answerLists}
+              intersectionObserveTargetRef={intersectionObserveTargetRef}
+            />
+            <p
+              ref={intersectionObserveTargetRef}
+              css={css`
+                position: relative;
+                width: 100%;
+                height: 0;
+              `}
+            />
+            {isVisible ? <ScrollTopButton onClickHandler={handleScrollToTop} /> : null}
+          </>
+        )}
+      </StBackground>
+    </>
   );
 };
 

--- a/src/pages/list-page/ListPage.jsx
+++ b/src/pages/list-page/ListPage.jsx
@@ -25,11 +25,9 @@ const ListPage = () => {
       <StNavWrapper>
         <StNav>
           <Logo onClickHandler={() => navigate('/')} />
-          {id ? (
-            <Button theme='brown20' arrow onClickHandler={navigateToAnswerPage}>
-              답변하러 가기
-            </Button>
-          ) : null}
+          <Button theme='brown20' arrow onClickHandler={navigateToAnswerPage}>
+            답변하러 가기
+          </Button>
         </StNav>
       </StNavWrapper>
       <ListContents />

--- a/src/pages/main-page/MainPage.jsx
+++ b/src/pages/main-page/MainPage.jsx
@@ -45,6 +45,7 @@ const MainPage = () => {
       <StMainWrapper>
         <Logo pcWidth='46.3rem' pcHeight='18rem' width='25.1rem' height='9.8rem' />
         <StInputName>
+          <StDescription>질문을 받으려면 이름을 입력해 주세요</StDescription>
           <InputField onChangeHandler={handleInputChange} />
           <Button width='100%' onClickHandler={() => handlePost(userName)}>
             질문 받기
@@ -104,4 +105,9 @@ const StButtonPosition = styled.div`
     top: 50px;
     right: 5vh;
   }
+`;
+
+const StDescription = styled.p`
+  font-size: 1.6rem;
+  margin-bottom: 4px;
 `;

--- a/src/pages/question-feed-page/QuestFeedPage.jsx
+++ b/src/pages/question-feed-page/QuestFeedPage.jsx
@@ -10,6 +10,7 @@ import ScrollTopButton from '@components/ui/atoms/scroll-top/ScrollTopButton';
 import FeedCardContainer from '@components/ui/molecules/feed-card/FeedCardContainer';
 import AddQuestionModal from '@components/ui/molecules/modal/AddQuestionModal';
 import NavBar from '@components/ui/molecules/nav-bar/NavBar';
+import DocumentTitle from '@layout/document-title/DocumentTitle';
 import NoLists from '@pages/list-page/comp/list-contents/comp/no-lists/NoLists';
 
 import { getAnswerLists } from '@api/answers/getAnswerLists';
@@ -91,6 +92,7 @@ const QuestFeedPage = () => {
 
   return (
     <>
+      <DocumentTitle>질문 모아보기 페이지</DocumentTitle>
       <StBackground>
         <NavBar />
         <StQuestFeedPageWrapper>

--- a/src/pages/question-feed-page/QuestFeedPage.jsx
+++ b/src/pages/question-feed-page/QuestFeedPage.jsx
@@ -18,6 +18,7 @@ import getUserData from '@api/subjects/getUserData';
 import { useAsync_V2 } from '@hooks/useAsync_V2';
 import { useAsyncOnMount } from '@hooks/useAsyncOnMount';
 // import { useModalComponent } from '@hooks/useModalComponent';
+import { useCheckAuth } from '@hooks/useCheckAuth';
 import { useCloseModal } from '@hooks/useCloseModal';
 import { useInView } from '@hooks/useInView';
 import useScrollToTop from '@hooks/useScrollToTop';
@@ -27,6 +28,7 @@ import { getQueryStringObject } from '@utils/url/getQueryStringObject';
 const QuestFeedPage = () => {
   const { copyUrl, shareToFacebook, shareToKakaotalk } = useSNSShare();
   const { id: userId } = useParams();
+  const { isUser } = useCheckAuth();
 
   const [requestType, setRequestType] = useState('mount'); // 'default' | 'mount' | 'delete' | 'deleteAll' | 'edit' | 'reply' ---> 전부 다 처음부터 불러올 거
   const [answerLists, setAnswerLists] = useState([]);
@@ -127,16 +129,18 @@ const QuestFeedPage = () => {
             />
           </>
         )}
-        <FloatingWriteQuestionButton
-          onClick={toggleModal}
-          css={
-            isVisible
-              ? css`
-                  right: 80px;
-                `
-              : null
-          }
-        />
+        {isUser ? null : (
+          <FloatingWriteQuestionButton
+            onClick={toggleModal}
+            css={
+              isVisible
+                ? css`
+                    right: 80px;
+                  `
+                : null
+            }
+          />
+        )}
         {isVisible ? <ScrollTopButton onClickHandler={handleScrollToTop} /> : null}
       </StBackground>
       <PortalContainer>


### PR DESCRIPTION
## 📝작업 내용

1. 로그인된 상태로 내 질문 페이지에 온다면 "질문하기" 버튼 보이지 않도록 처리
2. 페이지별 타이틀 적기
3. 리스트페이지 답변하러 가기 버튼 모두에게 보이도록
4. 로그인 인풋 박스 쪽에 설명 텍스트 추가
5. 거절 상태에서 수정 버튼 누르면 인풋에 기본 텍스트 들어가있는 것 -> 이렇게 했던 이유가 거절 보낼때에도 content가 비워져있으면 안되기 때문,,, 일단 설명 텍스트를 인풋에 넣어둔 것 인데 이것 관련하여 논의 필요해 보임
